### PR TITLE
chore: remove organization-slug from demos and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Add an element with `clayer-config` ID and populate its data attributes with you
     <div
       id="clayer-config"
       data-base-url="https://commercelayer-js-dropin.commercelayer.io"
-      data-organization-slug="commercelayer-js-dropin"
       data-cache="true"
       data-client-id="1756ba0fa1672ef1445eb2123ac156c91b2551befdde51dcca768a94edc1eae07"
       data-market-id="6371"
@@ -86,7 +85,7 @@ Add an element with `clayer-config` ID and populate its data attributes with you
     <!-- JS Library -->
     <script
       type="text/javascript"
-      src="https://cdn.jsdelivr.net/npm/@commercelayer/js-dropin@1.5.10/lib/index.js"
+      src="https://cdn.jsdelivr.net/npm/@commercelayer/js-dropin@1.5.11/lib/index.js"
     ></script>
   </body>
 </html>

--- a/demo/category-page.html
+++ b/demo/category-page.html
@@ -289,7 +289,7 @@
     <!-- JS Library -->
     <script
       type="text/javascript"
-      src="https://cdn.jsdelivr.net/npm/@commercelayer/js-dropin@1.5.9/lib/index.js"
+      src="https://cdn.jsdelivr.net/npm/@commercelayer/js-dropin@1.5.11/lib/index.js"
     ></script>
   </body>
 </html>

--- a/demo/product-page-radio.html
+++ b/demo/product-page-radio.html
@@ -203,7 +203,7 @@
   </div>
 
   <!-- JS Library -->
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@commercelayer/js-dropin@1.5.9/lib/index.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@commercelayer/js-dropin@1.5.11/lib/index.js"></script>
 
   </body>
 </html>

--- a/demo/product-page-select.html
+++ b/demo/product-page-select.html
@@ -169,7 +169,7 @@
   </div>
 
   <!-- JS Library -->
-  <script src="https://cdn.jsdelivr.net/npm/@commercelayer/js-dropin@1.5.9/lib/index.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@commercelayer/js-dropin@1.5.11/lib/index.js"></script>
 
   </body>
 </html>


### PR DESCRIPTION
This PR updates the demos and docs to match `v.1.5.11`